### PR TITLE
Allow param keys to be whitelisted

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ SELECT p0."foo", p0."baz" FROM posts as p0 WHERE (p0."foo" = $1) AND (p0."baz" =
 
 `$1` and `$2` will get the values of `"bar"` and `"qux"`,
 
+### Security ###
+
+Inquisitor will allow any key/value pair to be queried against, you will
+likely want to only allow access to a limited number of fields. To do
+this you can `whitelist` any number of fields that can be allowed to
+queried:
+
+```elixir
+use Inquisitor, with: MyApp.Post, whitelist: ["title", "body"]
+```
+
 ### Adding custom query handlers ###
 
 Simple key/value matching is not always what you want. In that case you

--- a/test/inquisitor_test.exs
+++ b/test/inquisitor_test.exs
@@ -1,43 +1,58 @@
 defmodule InquisitorTest do
   use ExUnit.Case
-  use Inquisitor, with: User
 
-  import Ecto.Query
+  defmodule Basic do
+    use Inquisitor, with: User
+    import Ecto.Query
 
-  alias Ecto.Adapters.Postgres.Connection, as: SQL
+    def build_user_query(query, [{"limit", limit}|t]) do
+      query
+      |> limit(^limit)
+      |> build_user_query(t) 
+    end
+  end
 
   def to_sql(q) do
     Ecto.Adapters.SQL.to_sql(:all, Repo, q)
   end
 
   test "will build a simple key/value query" do
-    q = build_user_query(%{"name" => "Brian"})
+    q = Basic.build_user_query(%{"name" => "Brian"})
     assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0 WHERE (u0."name" = $1)}, ["Brian"]}
   end 
 
   test "will combine multiple params with AND sql" do
-    q = build_user_query(%{"name" => "Brian", "age" => 36})
+    q = Basic.build_user_query(%{"name" => "Brian", "age" => 36})
     assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0 WHERE (u0."age" = $1) AND (u0."name" = $2)}, [36, "Brian"]}
   end
 
   test "will convert \"true\" to its boolean value" do
-    q = build_user_query(%{"verified" => "true"})
+    q = Basic.build_user_query(%{"verified" => "true"})
     assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0 WHERE (u0."verified" = $1)}, [true]}
   end
 
   test "will convert \"false\" to its boolean value" do
-    q = build_user_query(%{"verified" => "false"})
+    q = Basic.build_user_query(%{"verified" => "false"})
     assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0 WHERE (u0."verified" = $1)}, [false]}
   end
 
   test "can use custom composable query" do
-    q = build_user_query(%{"limit" => 20})
+    q = Basic.build_user_query(%{"limit" => 20})
     assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0 LIMIT $1}, [20]}
   end
 
-  def build_user_query(query, [{"limit", limit}|t]) do
-    query
-    |> limit(^limit)
-    |> build_user_query(t) 
+  defmodule Whitelist do
+    use Inquisitor, with: User, whitelist: ["name"]
+    import Ecto.Query
+  end
+
+  test "allows whitelisted fields to be queried" do
+    q = Whitelist.build_user_query(%{"name" => "Brian"})
+    assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0 WHERE (u0."name" = $1)}, ["Brian"]}
+  end
+
+  test "disallows fields not whitelisted to be queried" do
+    q = Whitelist.build_user_query(%{"age" => 36})
+    assert to_sql(q) == {~s{SELECT u0."id", u0."name", u0."age", u0."verified" FROM "users" AS u0}, []}
   end
 end


### PR DESCRIPTION
Closes #1

Adds layer of security by allowing opt-in whitefiltering on params.
