### PR TITLE
Don't assume Ecto.Query is imported

### DIFF
--- a/lib/inquisitor.ex
+++ b/lib/inquisitor.ex
@@ -80,7 +80,7 @@ defmodule Inquisitor do
       def unquote(fn_name)(query, []), do: query
       def unquote(fn_name)(query, [{attr, value}|tail]) do
         query
-        |> where([r], field(r, ^String.to_existing_atom(attr)) == ^value)
+        |> Ecto.Query.where([r], field(r, ^String.to_existing_atom(attr)) == ^value)
         |> unquote(fn_name)(tail)
       end
     end

--- a/test/inquisitor_test.exs
+++ b/test/inquisitor_test.exs
@@ -3,11 +3,11 @@ defmodule InquisitorTest do
 
   defmodule Basic do
     use Inquisitor, with: User
-    import Ecto.Query
+    import Ecto.Query, only: [from: 1, from: 2]
 
     def build_user_query(query, [{"limit", limit}|t]) do
       query
-      |> limit(^limit)
+      |> Ecto.Query.limit(^limit)
       |> build_user_query(t) 
     end
   end


### PR DESCRIPTION
It is best to use the fully qualified function name rather than assuming
Ecto.Query is imported
