### PR TITLE
Resolve compile warning for Mix 1.4.0

### DIFF
--- a/lib/inquisitor.ex
+++ b/lib/inquisitor.ex
@@ -109,6 +109,6 @@ defmodule Inquisitor do
   defp name_from_model(model) do
     Module.split(model)
     |> List.last()
-    |> Mix.Utils.underscore()
+    |> Macro.underscore()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule Inquisitor.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
-     deps: deps,
+     description: description(),
+     package: package(),
+     deps: deps(),
      docs: [
       main: "Inquisitor"
      ]]


### PR DESCRIPTION
```
warning: Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead
  (mix) lib/mix/utils.ex:244: Mix.Utils.underscore/1
  (inquisitor) lib/inquisitor.ex:69: Inquisitor.MACRO-__before_compile__/2
  (elixir) src/elixir_dispatch.erl:185: :elixir_dispatch.expand_macro_fun/6
  (elixir) src/elixir_dispatch.erl:170: :elixir_dispatch.expand_require/5
  (elixir) src/elixir_dispatch.erl:99: :elixir_dispatch.dispatch_require/6
```
