### PR TITLE
Add explicitness to functions

### DIFF
--- a/lib/inquisitor.ex
+++ b/lib/inquisitor.ex
@@ -40,22 +40,26 @@ defmodule Inquisitor do
         Ecto.Query.where(query, [r], r.title == ^title)
       end
 
+  See `Inquisitor.QueryBuilder` for more documentation.
+
   """
   defmacro __using__(_opts) do
     quote do
-      def build_query(query, context, params) do
+      @behaviour Inquisitor.QueryBuilder
+
+      @doc """
+      Builds an Ecto Query.
+      """
+      @spec build_query(Ecto.Queryable.t(), any(), map()) :: Ecto.Query.t()
+      def build_query(queryable, context, params) do
+        query = Ecto.Queryable.to_query(queryable)
         Enum.reduce(params, query, fn({key, value}, query) ->
           build_query(query, key, value, context)
         end)
       end
 
-      @before_compile Inquisitor
-    end
-  end
+      def build_query(%Ecto.Query{} = query, _key, _value, _context), do: query
 
-  defmacro __before_compile__(_env) do
-    quote do
-      def build_query(query, _key, _value, _context), do: query
       defoverridable [build_query: 4]
     end
   end

--- a/lib/inquisitor/query_builder.ex
+++ b/lib/inquisitor/query_builder.ex
@@ -1,0 +1,24 @@
+defmodule Inquisitor.QueryBuilder do
+  @moduledoc """
+  Behaviour for building queries with Inquisitor.
+  """
+
+  @type query :: Ecto.Query.t()
+  @type key :: String.t() | atom
+  @type value :: term()
+  @type context :: map()
+
+  @doc """
+  Callback to handle specific values when building the query.
+
+  For instance, you may have a column in your schema that is always lowercase.
+
+      @impl Inquisitor.QueryBuilder
+      def build_query(%Ecto.Query{} = query, "email", value, _) do
+        Ecto.Query.where(query, email: ^String.downcase(value))
+      end
+
+  end
+  """
+  @callback build_query(query, key, value, context) :: query
+end

--- a/mix.exs
+++ b/mix.exs
@@ -49,8 +49,8 @@ defmodule Inquisitor.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:ecto, "> 2.0.0"},
       {:plug, "~> 1.3.0", only: :test},
-      {:ecto, "> 2.0.0", only: :test},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
       {:postgrex, "> 0.0.0", only: :test}


### PR DESCRIPTION
This adds explicitness to the code by defining a callback for building the query as well as using actual Ecto types.